### PR TITLE
Update prefix_nodes_move_old_paths_after_update.sql

### DIFF
--- a/sql/prefix_nodes_move_old_paths_after_update.sql
+++ b/sql/prefix_nodes_move_old_paths_after_update.sql
@@ -13,7 +13,7 @@ CREATE
     END IF;
 
     IF OLD.`is_deleted` != NEW.`is_deleted` THEN
-        CALL p_prefix_nodes_delete_nodes_after_update(NEW.`parent_id`);
+        CALL p_prefix_nodes_delete_nodes_after_update(NEW.`parent_id`, NEW.`is_deleted`);
     END IF;
 END;
 $$


### PR DESCRIPTION
included the missing second parameter to the call to the procedure 'p_prefix_nodes_delete_nodes_after_update'
