### PR TITLE
Fixed broken trees when changing parent to NULL

### DIFF
--- a/mysql/all-in-one.sql
+++ b/mysql/all-in-one.sql
@@ -50,7 +50,7 @@ DROP TRIGGER IF EXISTS `trigger_move_node`$$
 
 CREATE TRIGGER `trigger_move_node` AFTER UPDATE ON `prefix_nodes`
   FOR EACH ROW BEGIN
-  IF OLD.`parent_id` != NEW.`parent_id` THEN
+  IF NOT OLD.`parent_id` <=> NEW.`parent_id` THEN
     -- http://www.mysqlperformanceblog.com/2011/02/14/moving-subtrees-in-closure-table/
     -- in the example, when change node D's parent to B.
     -- its sql has only D & B. so I think it should currentNode.id& newParent.id

--- a/mysql/triggers/trigger_move_node.sql
+++ b/mysql/triggers/trigger_move_node.sql
@@ -6,7 +6,7 @@ DROP TRIGGER IF EXISTS `trigger_move_node`$$
 
 CREATE TRIGGER `trigger_move_node` AFTER UPDATE ON `prefix_nodes`
   FOR EACH ROW BEGIN
-  IF OLD.`parent_id` != NEW.`parent_id` THEN
+  IF NOT OLD.`parent_id` <=> NEW.`parent_id` THEN
     -- http://www.mysqlperformanceblog.com/2011/02/14/moving-subtrees-in-closure-table/
     -- in the example, when change node D's parent to B.
     -- its sql has only D & B. so I think it should currentNode.id& newParent.id


### PR DESCRIPTION
Lack of `null` safe comparison lead to procedure not being called when changing node's parent to `null`